### PR TITLE
Add additional keyboard support

### DIFF
--- a/PianoKeys/PKPianobarController.m
+++ b/PianoKeys/PKPianobarController.m
@@ -49,12 +49,14 @@
         case NX_KEYTYPE_PLAY:
             [self sendDelayedCommand:COMMAND_LOVE];
             break;
-            
+
         case NX_KEYTYPE_FAST:
+        case NX_KEYTYPE_NEXT:
             [self sendDelayedCommand:COMMAND_BAN];
             break;
-            
+
         case NX_KEYTYPE_REWIND:
+        case NX_KEYTYPE_PREVIOUS:
         default:
             break;
     }
@@ -86,10 +88,12 @@
             break;
         
         case NX_KEYTYPE_FAST:
+        case NX_KEYTYPE_NEXT:
             [self sendCommand:COMMAND_FAST];
             break;
         
         case NX_KEYTYPE_REWIND:
+        case NX_KEYTYPE_PREVIOUS:
         default:
             break;
     }
@@ -151,6 +155,8 @@
 - (BOOL)shouldHandleMediaKey:(int)keyCode {
     switch (keyCode) {
         case NX_KEYTYPE_PLAY:
+        case NX_KEYTYPE_NEXT:
+        case NX_KEYTYPE_PREVIOUS:
         case NX_KEYTYPE_FAST:
         case NX_KEYTYPE_REWIND:
             return YES;

--- a/PianoKeys/SPMediaKey/SPMediaKeyTap.m
+++ b/PianoKeys/SPMediaKey/SPMediaKeyTap.m
@@ -176,7 +176,7 @@ static CGEventRef tapEventCallback2(CGEventTapProxy proxy, CGEventType type, CGE
 		return event;
 
 	int keyCode = (([nsEvent data1] & 0xFFFF0000) >> 16);
-	if (keyCode != NX_KEYTYPE_PLAY && keyCode != NX_KEYTYPE_FAST && keyCode != NX_KEYTYPE_REWIND)
+	if (keyCode != NX_KEYTYPE_PLAY && keyCode != NX_KEYTYPE_NEXT && keyCode != NX_KEYTYPE_PREVIOUS && keyCode != NX_KEYTYPE_FAST && keyCode != NX_KEYTYPE_REWIND)
 		return event;
 
 	if (![self shouldInterceptMediaKeyEvents])


### PR DESCRIPTION
Some of the mac keyboards I have were sending different keycodes. This commit lets those keyboards function along side the originally supported keyboards.
